### PR TITLE
Include types when not using introspect but don't reflect schema

### DIFF
--- a/graphql_server/lib/graphql_server2.dart
+++ b/graphql_server/lib/graphql_server2.dart
@@ -57,16 +57,16 @@ class GraphQL {
       this.customTypes.addAll(customTypes);
     }
 
+    var allTypes = fetchAllTypes(schema, [...this.customTypes]);
+
     if (introspect) {
-      var allTypes = fetchAllTypes(schema, [...this.customTypes]);
-
       _schema = reflectSchema(_schema, allTypes);
+    }
 
-      for (var type in allTypes.toSet()) {
-        if (!this.customTypes.contains(type)) {
-          if (type != null) {
-            this.customTypes.add(type);
-          }
+    for (var type in allTypes.toSet()) {
+      if (!this.customTypes.contains(type)) {
+        if (type != null) {
+          this.customTypes.add(type);
         }
       }
     }


### PR DESCRIPTION
Prevents errors when querying with introspection disabled. Fixes #4.