### PR TITLE
Fixed a stackoverflow bug when handling complex nested input types

### DIFF
--- a/graphql_server/lib/graphql_server2.dart
+++ b/graphql_server/lib/graphql_server2.dart
@@ -257,8 +257,8 @@ class GraphQL {
     for (final val in map.values) {
       if (val is JsonPathArgument) {
         lazy.add([...val.splitted, val]);
-      } else if (val is Map) {
-        makeLazy(map);
+      } else if (val is Map<String, dynamic>) {
+        makeLazy(val);
       }
     }
 


### PR DESCRIPTION
This PR fixes a stackoverflow exception when a mutation request with complex nested input objects gets handled.


The following request lead to an exception:
```graphql
mutation invite($invitation: EventInput!) {
  push_invitation(event: $invitation)
}

# Variables:
{
  "invitation": {
      "name": "Cool event",
      "secret": "1234"
  }
}
```

The original result was this:
```json
{
  "errors": [
    {
      "message": "Stack Overflow"
    }
  ]
}
```

With this PR the correct result is the following:
```json
{
  "data": {
    "push_invitation": true
  }
}
```